### PR TITLE
Unset GTK_IM_MODULE to let applications choose their own backend

### DIFF
--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -99,6 +99,9 @@
             SDL_VIDEODRIVER = "wayland";
             CLUTTER_BACKEND = "wayland";
 
+            # Unset GTK_IM_MODULE so apps can figure it out themselves
+            GTK_IM_MODULE="";
+
         } // lib.attrsets.optionalAttrs config.js.hardware.nvidia.enable {
 
             # Recommended NVIDIA variables

--- a/modules/desktop/jpkb.nix
+++ b/modules/desktop/jpkb.nix
@@ -30,7 +30,6 @@
             };
         };
 
-        environment.sessionVariables.GTK_IM_MODULE = "wayland";
         environment.sessionVariables.GLFW_IM_MODULE = "ibus";
 
     };


### PR DESCRIPTION
This PR moves the environment variable declaration for `GTK_IM_MODULE` from the JPKB module to the Hyprland module and unsets the value. If the value isn't defined in the config, it defaults to Wayland; however, keeping the value blank allows applications to use whatever backend they want, whether that's Wayland or X11 (via XWayland). Fixes #4.